### PR TITLE
feature/#5 - Image Picker Component 구현

### DIFF
--- a/project-team-card-app/ImagePicker.swift
+++ b/project-team-card-app/ImagePicker.swift
@@ -1,0 +1,80 @@
+//
+//  ImagePicker.swift
+//  project-team-card-app
+//
+//  Created by kingj on 3/4/25.
+//
+
+import UIKit
+
+/// Image Picker Component
+class ImagePicker: UIView {
+    
+    /// Image Picker Controller instance
+    var imagePickerController = UIImagePickerController()
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+    }
+        
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+/// ** 해당 주석 아래 코드를 UIViewController에서 사용 후 삭제 **
+// TODO: 1. 본인 UIViewController 이름으로 변경
+// TODO: 2. ImagePicker 객체 생성
+//          > ImagePicker 프로퍼티 imagePickerController 사용을 위함
+// TODO: 3. UIImagePickerControllerDelegate & UINavigationControllerDelegate Protocol 을 extension 하여, 아래 메소드 모두 추가
+// TODO: 4. viewDidLoad()에 imagePickerAction() 선언
+
+extension 뷰컨트롤러: UIImagePickerControllerDelegate & UINavigationControllerDelegate {
+    
+    private func imagePickerAction() {
+        
+        // TODO: 본인 UIButton에 맞게 변경
+        ImagePicker버튼.addTarget(뷰컨트롤러.self, action: #selector(showImagePickerForLibrary), for: .touchUpInside)
+        ImagePicker버튼.imagePickerController.delegate = 뷰컨트롤러.self
+    }
+    
+    @objc func showImagePickerForLibrary() {
+        showImagePicker(sourceType: UIImagePickerController.SourceType.photoLibrary, imagePickerController: ImagePicker객체.imagePickerController)
+    }
+    
+    private func showImagePicker(sourceType: UIImagePickerController.SourceType, imagePickerController: UIImagePickerController) {
+        imagePickerController.sourceType = sourceType
+        imagePickerController.modalPresentationStyle = UIModalPresentationStyle.popover
+        imagePickerController.allowsEditing = true
+
+        self.present(imagePickerController, animated: true)
+    }
+    
+    // MARK: UIImagePickerControllerDelegate Method
+    /// 이미지 피커 컨트롤러에서 이미지를 선택하거나 카메라 촬영을 완료했을 때 호출되는 메소드
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        
+        let info = convertFromUIImagePickerControllerInfoKeyDictionary(info)
+        
+        guard let image = info[convertFromUIImagePickerControllerInfoKey(UIImagePickerController.InfoKey.editedImage)] as? UIImage else {
+            return
+        }
+        
+        dismiss(animated: false) {
+            // TODO: 본인 UIImageView에 맞게 변경
+            // MARK: - 선택된 이미지를 UIImageView에 넣는 코드
+            본인ImageView.image = image
+        }
+    }
+    
+    // MARK: - Utilities
+    private func convertFromUIImagePickerControllerInfoKeyDictionary(_ input: [UIImagePickerController.InfoKey: Any]) -> [String: Any] {
+        return Dictionary(uniqueKeysWithValues: input.map { key, value in (key.rawValue, value) })
+    }
+
+    private func convertFromUIImagePickerControllerInfoKey(_ input: UIImagePickerController.InfoKey) -> String {
+        return input.rawValue
+    }
+
+}

--- a/project-team-card-app/Info.plist
+++ b/project-team-card-app/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>${PRODUCT_NAME}가 사진을 등록하는 기능 사용을 위해 사진 라이브러리에 접근하도록 허용합니다. </string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Image Picker 구현 내용
1. Image Picker Component 를 구현
   - 선택 된 이미지 zoom-in/out 하여 편집 가능
  
2. 사진 라이브러리에 접근 권한을 설정하는 Alert 보내기
    - Info.plist > Information Property List > 
       - Key에 Privacy - Photo Library Usage Description 추가, 
       - Value에 "${PRODUCT_NAME}가 사진을 등록하는 기능 사용을 위해 사진 라이브러리에 접근하도록 허용합니다. " 추가


## Image Picker 사용 방법
1. TODO 로 각자의 UIViewController 에서 수정/사용 할 부분을 표시해뒀습니다. 
    >1. 본인 UIViewController 이름으로 변경
    >2. ImagePicker 객체 생성
        :  ImagePicker 프로퍼티 imagePickerController 사용을 위함
    >3. UIImagePickerControllerDelegate & UINavigationControllerDelegate Protocol 을 extension 하여, 아래 메소드 모두 추가
    >4. viewDidLoad()에 imagePickerAction() 선언

## Image Picker 구현 참고사항
1. Protocol 구현 부분은, 일부러 수정하기 쉽게 한글로 이름(변수/클래스) 을 넣어뒀습니다. 
    > 1. 근데 이게 좋은 방법인지는 모르겠슴당.. UIViewController 에서 가져다쓰는 보통의 경우에는, 저와 같은 경우 어떻게 올리는게 좋은지.. 혹시 알고 계시다면 알려주시면 감사하겠습니다🙇🏻‍♀️
    > 2. 주석땜에 좀 지저분해 보여서.. Image Picker Delegate 구현을 extension 파일로 빼두고 나중에 다 쓰고 삭제할까 했는데.. 파일 삭제로 혹시나 충돌날까봐 일단은 같이 올렸습니다
2. 향후, Image Editor 라이브러리 사용하면 좋을 것 같음